### PR TITLE
feat: add Coze integration with both Agent as API and Web SDK implementations

### DIFF
--- a/src/api/coze/index.js
+++ b/src/api/coze/index.js
@@ -1,0 +1,36 @@
+// Coze API 配置
+const COZE_API_CONFIG = {
+  baseURL: 'https://api.coze.cn/v3',
+  botId: '7429205852169142307',
+  userId: '2918520096325296'
+}
+
+// Coze API 客户端
+export class CozeApiClient {
+  constructor(token) {
+    this.token = token;
+  }
+
+  async chat(message) {
+    const response = await fetch(`${COZE_API_CONFIG.baseURL}/chat`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.token}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        bot_id: COZE_API_CONFIG.botId,
+        user_id: COZE_API_CONFIG.userId,
+        stream: true,
+        auto_save_history: true,
+        additional_messages: [{
+          role: 'user',
+          content: message,
+          content_type: 'text'
+        }]
+      })
+    });
+
+    return response;
+  }
+}

--- a/src/api/coze/types.ts
+++ b/src/api/coze/types.ts
@@ -1,0 +1,17 @@
+export interface CozeConfig {
+  baseURL: string;
+  botId: string;
+  userId: string;
+}
+
+export interface CozeMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  content_type: 'text';
+}
+
+export interface CozeResponse {
+  id: string;
+  conversation_id: string;
+  content: string;
+}

--- a/src/components/Chat/CozeChat.vue
+++ b/src/components/Chat/CozeChat.vue
@@ -1,0 +1,134 @@
+<template>
+  <div class="coze-chat">
+    <div class="chat-messages" ref="messagesContainer">
+      <div v-for="msg in messages" :key="msg.id" :class="['message', msg.role]">
+        {{ msg.content }}
+      </div>
+    </div>
+    <div class="chat-input">
+      <input v-model="inputMessage" @keyup.enter="sendMessage" placeholder="输入消息...">
+      <button @click="sendMessage">发送</button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { CozeApiClient } from '@/api/coze';
+
+export default {
+  name: 'CozeChat',
+  data() {
+    return {
+      client: null,
+      messages: [],
+      inputMessage: '',
+    }
+  },
+  created() {
+    this.client = new CozeApiClient(process.env.VUE_APP_COZE_TOKEN);
+  },
+  methods: {
+    async sendMessage() {
+      if (!this.inputMessage.trim()) return;
+      
+      const userMessage = {
+        role: 'user',
+        content: this.inputMessage,
+        id: Date.now()
+      };
+      
+      this.messages.push(userMessage);
+      this.inputMessage = '';
+
+      try {
+        const response = await this.client.chat(userMessage.content);
+        const reader = response.body.getReader();
+        let partialMessage = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          
+          const text = new TextDecoder().decode(value);
+          const events = text.split('\n\n');
+          
+          for (const event of events) {
+            if (event.startsWith('data:')) {
+              const data = JSON.parse(event.slice(5));
+              if (data.content) {
+                partialMessage += data.content;
+              }
+            }
+          }
+        }
+
+        this.messages.push({
+          role: 'assistant',
+          content: partialMessage,
+          id: Date.now()
+        });
+      } catch (error) {
+        console.error('发送消息失败:', error);
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.coze-chat {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+}
+
+.message {
+  margin: 10px 0;
+  padding: 10px;
+  border-radius: 8px;
+}
+
+.user {
+  background: #e3f2fd;
+  margin-left: 20%;
+}
+
+.assistant {
+  background: #f5f5f5;
+  margin-right: 20%;
+}
+
+.chat-input {
+  display: flex;
+  padding: 20px;
+  gap: 10px;
+}
+
+input {
+  flex: 1;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+button {
+  padding: 10px 20px;
+  background: #1976d2;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button:hover {
+  background: #1565c0;
+}
+</style>

--- a/src/examples/coze/AgentAsAPI.vue
+++ b/src/examples/coze/AgentAsAPI.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="agent-as-api-demo">
+    <h2>Coze Agent as API Demo</h2>
+    <CozeChat />
+  </div>
+</template>
+
+<script>
+import CozeChat from '@/components/Chat/CozeChat.vue'
+
+export default {
+  name: 'AgentAsAPIDemo',
+  components: {
+    CozeChat
+  }
+}
+</script>

--- a/src/examples/coze/WebSDK.vue
+++ b/src/examples/coze/WebSDK.vue
@@ -1,0 +1,25 @@
+<template>
+  <div class="web-sdk-demo">
+    <h2>Coze Web SDK Demo</h2>
+    <div id="coze-container"></div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'WebSDKDemo',
+  mounted() {
+    // Web SDK implementation
+    const script = document.createElement('script');
+    script.src = 'https://cdn.coze.cn/sdk/latest/coze.js';
+    document.head.appendChild(script);
+
+    script.onload = () => {
+      window.Coze.init({
+        appId: process.env.VUE_APP_COZE_APP_ID,
+        container: '#coze-container'
+      });
+    };
+  }
+}
+</script>


### PR DESCRIPTION
 # Coze 集成实现

## 功能说明
- 添加了 Coze Agent as API 实现
- 添加了 Coze Web SDK 实现
- 提供了两种集成方式的示例组件

## 主要更改
- 新增 src/api/coze 目录：API 客户端实现
- 新增 src/components/Chat：聊天组件
- 新增 src/examples/coze：使用示例

## 使用方法
1. Agent as API 方式：
javascript
import { CozeApiClient } from '@/api/coze';
const client = new CozeApiClient(process.env.VUE_APP_COZE_TOKEN);

2. Web SDK 方式：
javascript
import WebSDKDemo from '@/examples/coze/WebSDK.vue';

## 环境变量要求
- VUE_APP_COZE_TOKEN：Coze API Token
- VUE_APP_COZE_APP_ID：Coze App ID（仅 Web SDK 方式需要）
  --base main
  --head feature/coze-integration